### PR TITLE
Reference arb implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
       "setup": "forge clean && forge build",
       "update": "forge update",
       "test": "forge clean && forge test",
+      "cov": "forge clean && forge coverage --report lcov && genhtml -o report lcov.info",
       "snapshot": "forge clean && forge snapshot",
       "lint": "prettier --write src/**/*.sol && prettier --write src/*.sol"
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
       "test": "forge clean && forge test",
       "cov": "forge clean && forge coverage --report lcov && genhtml -o report lcov.info",
       "snapshot": "forge clean && forge snapshot",
-      "lint": "prettier --write src/**/*.sol && prettier --write src/*.sol"
+      "lint": "prettier --print-width 120 --write src/**/*.sol && prettier --print-width 120 --write src/*.sol"
   }
 }

--- a/src/Helios.sol
+++ b/src/Helios.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.4;
 import {IHelios} from "./interfaces/IHelios.sol";
 import {OwnedThreeStep} from "@solbase/auth/OwnedThreeStep.sol";
 import {SafeTransferLib} from "@solbase/utils/SafeTransferLib.sol";
+import {FixedPointMathLib} from "@solbase/utils/FixedPointMathLib.sol";
 import {SafeMulticallable} from "@solbase/utils/SafeMulticallable.sol";
 import {ERC1155, ERC1155TokenReceiver} from "@solbase/tokens/ERC1155.sol";
 
@@ -22,6 +23,7 @@ contract Helios is
     /// -----------------------------------------------------------------------
 
     using SafeTransferLib for address;
+    using FixedPointMathLib for uint256;
 
     /// -----------------------------------------------------------------------
     /// Events
@@ -57,6 +59,14 @@ contract Helios is
     );
 
     event SetURIfetcher(ERC1155 indexed uriFetcher);
+
+    event AddOpportunity(uint256 id, uint256[] opportunity);
+
+    event ClearOpportunities();
+
+    event SetArbToken(address indexed token);
+
+    event SetArbBeneficiary(address indexed recipient);
 
     /// -----------------------------------------------------------------------
     /// Metadata/URI Logic
@@ -105,6 +115,19 @@ contract Helios is
     }
 
     /// -----------------------------------------------------------------------
+    /// Arb Storage
+    /// -----------------------------------------------------------------------
+
+    /// @dev Token that will be used for profits
+    address arbToken;
+
+    /// @dev Account where arb profits will be deposited
+    address beneficiary;
+
+    /// @dev List of arbitrage opportunities
+    uint256[][] opportunity;
+
+    /// -----------------------------------------------------------------------
     /// LP Logic
     /// -----------------------------------------------------------------------
 
@@ -133,12 +156,14 @@ contract Helios is
 
         require(address(swapper).code.length != 0, "Helios: INVALID_SWAPPER");
 
+        uint112 token0amount; 
+        uint112 token1amount; 
         // Sort tokens and amounts.
         (
-            address token0,
-            uint112 token0amount,
-            address token1,
-            uint112 token1amount
+            tokenA,
+            token0amount,
+            tokenB,
+            token1amount
         ) = tokenA < tokenB
                 ? (tokenA, uint112(tokenAamount), tokenB, uint112(tokenBamount))
                 : (
@@ -149,23 +174,23 @@ contract Helios is
                 );
 
         require(
-            pairSettings[token0][token1][swapper][fee] == 0,
+            pairSettings[tokenA][tokenB][swapper][fee] == 0,
             "Helios: PAIR_EXISTS"
         );
 
         // If null included or `msg.value`, assume native token pairing.
-        if (address(token0) == address(0) || msg.value != 0) {
+        if (address(tokenA) == address(0) || msg.value != 0) {
             // Overwrite token0 with null if not so.
-            if (token0 != address(0)) token0 = address(0);
+            if (tokenA != address(0)) tokenA = address(0);
 
             // Overwrite token0amount with value.
             token0amount = uint112(msg.value);
 
-            token1.safeTransferFrom(msg.sender, address(this), token1amount);
+            tokenB.safeTransferFrom(msg.sender, address(this), token1amount);
         } else {
-            token0.safeTransferFrom(msg.sender, address(this), token0amount);
+            tokenA.safeTransferFrom(msg.sender, address(this), token0amount);
 
-            token1.safeTransferFrom(msg.sender, address(this), token1amount);
+            tokenB.safeTransferFrom(msg.sender, address(this), token1amount);
         }
 
         // Unchecked because the only math done is incrementing
@@ -174,11 +199,11 @@ contract Helios is
             id = ++totalSupply;
         }
 
-        pairSettings[token0][token1][swapper][fee] = id;
+        pairSettings[tokenA][tokenB][swapper][fee] = id;
 
         pairs[id] = Pair({
-            token0: token0,
-            token1: token1,
+            token0: tokenA,
+            token1: tokenB,
             swapper: swapper,
             reserve0: token0amount,
             reserve1: token1amount,
@@ -192,7 +217,7 @@ contract Helios is
 
         totalSupplyForId[id] = liq;
 
-        emit CreatePair(to, id, token0, token1);
+        emit CreatePair(to, id, tokenA, tokenB);
 
         emit AddLiquidity(to, id, token0amount, token1amount);
     }
@@ -342,7 +367,10 @@ contract Helios is
             // We combine the updates into one write
             uint256 combinedUpdate = (amountIn << 112) - amountOut;
             assembly {
-                sstore(add(pair.slot, 3), add(sload(add(pair.slot, 3)), combinedUpdate))
+                sstore(
+                    add(pair.slot, 3),
+                    add(sload(add(pair.slot, 3)), combinedUpdate)
+                )
             }
         } else {
             pair.token1.safeTransfer(to, amountOut);
@@ -352,11 +380,15 @@ contract Helios is
             // We combine the updates into one write
             uint256 combinedUpdate = (amountOut << 112) - amountIn;
             assembly {
-                sstore(add(pair.slot, 3), sub(sload(add(pair.slot, 3)), combinedUpdate))
+                sstore(
+                    add(pair.slot, 3),
+                    sub(sload(add(pair.slot, 3)), combinedUpdate)
+                )
             }
         }
 
         emit Swap(to, id, tokenIn, amountIn, amountOut);
+        _arb();
     }
 
     /// @notice Update reserves of Helios LP.
@@ -446,5 +478,275 @@ contract Helios is
         } else {
             tokenOut.safeTransfer(to, amountOut);
         }
+        _arb();
+    }
+
+    /// -----------------------------------------------------------------------
+    /// Arbitrage logic
+    /// -----------------------------------------------------------------------
+
+    /// @notice Set the arbitrage token.
+    /// @param token Profits will be taken / denominated in this token.
+    function setArbToken(address token) external onlyOwner {
+        require(opportunity.length == 0, "Helios: NONEMPTY_OPPORTUNITIES");
+        arbToken = token;
+        emit SetArbToken(token);
+    }
+
+    /// @notice Set the account which will collect all arbitrage profits.
+    /// @param recipient Profits will be transferred to this address.
+    function setArbBeneficiary(address recipient) external onlyOwner {
+        beneficiary = recipient;
+        emit SetArbBeneficiary(recipient);
+    }
+
+    /// @notice Add an arbitrage cycle into consideration.
+    /// @param cycle Array of Helios LP ids in 1155 tracking.
+    function addOpportunity(uint256[] calldata cycle) public onlyOwner {
+        uint256 opp = opportunity.length;
+        address currentToken = arbToken;
+        uint256 len = cycle.length;
+
+        require(len > 0, "Helios: NOT_CYCLE");
+
+        for (uint256 i = 0; i < len; ++i) {
+            uint256 id = cycle[i];
+
+            require(id <= totalSupply, "Helios: PAIR_DOESNT_EXIST");
+
+            Pair storage pair = pairs[id];
+            address token0 = pair.token0;
+            address token1 = pair.token1;
+
+            require(
+                currentToken == token0 || currentToken == token1,
+                "Helios: NOT_PAIR_TOKEN"
+            );
+
+            currentToken = (currentToken == token1) ? token0 : token1;
+        }
+        require(currentToken == arbToken, "Helios: NOT_CYCLE");
+
+        opportunity.push(cycle);
+
+        emit AddOpportunity(opp, cycle);
+    }
+
+    /// @notice Remove all arbitrage cycles from consideration.
+    function clearOpportunities() public onlyOwner {
+        delete opportunity;
+        emit ClearOpportunities();
+    }
+
+    /// @notice Calculate and execute arbitrage if necessary.
+    /// @return the amount of profit from the arbitrage.
+    function _arb() internal returns (uint256) {
+        if (opportunity.length == 0) return 0;
+        (uint256 bestArbAmount, uint256 bestProfit) = _optimizeArb(0);
+        uint256 bestOpportunity = 0;
+        for (uint256 i = 1; i < opportunity.length;) {
+            (uint256 arbAmount, uint256 profit) = _optimizeArb(i);
+            if (profit > bestProfit)
+            {
+                bestProfit = profit;
+                bestArbAmount = arbAmount;
+                bestOpportunity = i;
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        if (bestProfit == 0) return 0;
+        (bool success, bytes memory result) = address(this).call(
+            abi.encodeCall(this.executeArb, (bestOpportunity, bestArbAmount))
+        );
+        return success ? abi.decode(result, (uint256)) : 0;
+    }
+
+    /// @notice Updates K, M according to the arb recurrence (cf. whitepaper)
+    /// @param id The Helios LP id in 1155 tracking
+    /// @param tokenIn The asset to swap from
+    /// @param K The K value
+    /// @param M The M value
+    /// @return tokenOut The asset to swap to
+    /// @return Knew new value of K
+    /// @return Mnew new value of M
+    function _updateRecurrence(
+        uint256 id,
+        address tokenIn,
+        uint256 K,
+        uint256 M
+    )
+        internal
+        view
+        returns (
+            address tokenOut,
+            uint256 Knew,
+            uint256 Mnew
+        )
+    {
+        Pair storage pair = pairs[id];
+        address token0 = pair.token0;
+        address token1 = pair.token1;
+
+        uint256 reserveIn;
+        uint256 reserveOut;
+        if (tokenIn == token1) {
+            tokenOut = token0;
+            reserveIn = pair.reserve1;
+            reserveOut = pair.reserve0;
+        } else {
+            tokenOut = token1;
+            reserveIn = pair.reserve0;
+            reserveOut = pair.reserve1;
+        }
+        uint256 fee = pair.fee;
+        Mnew = M - pair.swapper.getAmountOut(K, reserveIn, M, fee);
+        Knew = pair.swapper.getAmountOut(K, reserveIn, reserveOut, fee);
+    }
+
+    /// @notice calculate the amount to arb for a given opportunity
+    /// @notice All checks done earlier in addOpportunity; no checks here.
+    /// @param cycleId Index of cycle in the opportunity array.
+    /// @return amountArb The amount to arb to maximize profit
+    /// @return profit The estimated profit
+    function _optimizeArb(uint256 cycleId)
+        internal
+        view
+        returns (uint256, uint256)
+    {
+        uint256[] memory cycle = opportunity[cycleId];
+        Pair storage pair = pairs[cycle[0]];
+        address tokenOut = pair.token1;
+        uint256 K;
+        uint256 M;
+        if (arbToken == tokenOut) {
+            //tokenIn = token1 reserveIn=reserve1
+            tokenOut = pair.token0;
+            K = pair.reserve0;
+            M = pair.reserve1;
+        } else {
+            //tokenIn = token0 reserveIn=reserve0
+            K = pair.reserve1;
+            M = pair.reserve0;
+        }
+        M = (10000 * M) / (10000 - pair.fee);
+
+        uint256 len = cycle.length;
+        for (uint256 i = 1; i < len; ) {
+            (tokenOut, K, M) = _updateRecurrence(cycle[i], tokenOut, K, M);
+            unchecked {
+                ++i;
+            }
+        }
+        if (K > M){
+            uint256 amountArb = (K * M).sqrt() - M;
+            if (K - M > (amountArb << 1))
+                return (amountArb, K - M  - (amountArb << 1));
+        }
+        return (0, 0);
+    }
+
+    /// @notice Update reserves of Helios LP along an arbitrage cycle.
+    /// @notice All checks done earlier in addOpportunity; no checks here.
+    /// @param to The recipient, only used for logging events
+    /// @param cycleId The index of the cycle in the opportunity array
+    /// @param amountIn The amount of arbToken to swap
+    /// @return amountOut The amount of arbToken to receive
+    function _updateReservesUnchecked(
+        address to,
+        uint256 cycleId,
+        uint256 amountIn
+    ) internal returns (uint256 amountOut) {
+        uint256[] memory ids = opportunity[cycleId];
+        address currentToken = arbToken;
+        uint256 len = ids.length;
+        for (uint256 i; i < len; ) {
+            uint256 id = ids[i];
+            Pair storage pair = pairs[id];
+
+            // Swapper dictates output amount.
+            amountOut = pair.swapper.swap(id, address(currentToken), amountIn);
+
+            emit Swap(to, id, currentToken, amountIn, amountOut);
+
+            if (currentToken == pair.token1) {
+                currentToken = pair.token0;
+
+                pair.reserve0 -= uint112(amountOut);
+
+                pair.reserve1 += uint112(amountIn);
+            } else {
+                currentToken = pair.token1;
+
+                pair.reserve0 += uint112(amountIn);
+
+                pair.reserve1 -= uint112(amountOut);
+            }
+
+            amountIn = amountOut;
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @notice Execute an arb trade along the given arb cycle.
+    /// @dev All checks done earlier in addOpportunity; no checks here.
+    /// @dev This function should be low-level call'ed.
+    /// @dev It may revert but caller changes (swap) should persist.
+    /// @param cycleId The index of the cycle in the opportunity array
+    /// @param amountIn The amount of arbToken to arb
+    /// @return amountOut The profit amount
+    function executeArb(uint256 cycleId, uint256 amountIn)
+        public
+        returns (uint256 amountOut)
+    {
+        // Function is external to allow low-level call() (or try/catch)
+        // However we need to prevent calls from outside this contract
+        // since all checks have been moved to addOpportunity
+        require(msg.sender == address(this));
+        amountOut = amountIn;
+        uint256[] memory cycle = opportunity[cycleId];
+        address currentToken = arbToken;
+        uint256 initialAmountIn = amountIn;
+        uint256 len = cycle.length;
+        for (uint256 i; i < len; ) {
+            (currentToken, amountOut) = _updateReserves(
+                beneficiary,
+                cycle[i],
+                currentToken,
+                amountOut
+            );
+
+            unchecked {
+                ++i;
+            }
+        }
+        // Optimal arb was derived using real numbers.
+        // Still a small chance that rounding can lead to amountOut <= initialAmountIn
+        require(amountOut > initialAmountIn, "Helios: ARB_FAILED");
+        amountOut -= initialAmountIn;
+        if (address(arbToken) == address(0)) {
+            beneficiary.safeTransferETH(amountOut);
+        } else {
+            arbToken.safeTransfer(beneficiary, amountOut);
+        }
+    }
+
+    function _getAmountOut(
+        uint256 amountIn,
+        uint256 reserveAmountIn,
+        uint256 reserveAmountOut,
+        uint256 fee
+    ) internal pure returns (uint256 amountOut) {
+        uint256 amountInWithFee = amountIn * (10000 - fee);
+
+        uint256 newReserveIn = reserveAmountIn * 10000 + amountInWithFee;
+
+        amountOut =
+            (amountInWithFee * reserveAmountOut + (newReserveIn >> 1)) /
+            newReserveIn;
     }
 }

--- a/src/Helios.sol
+++ b/src/Helios.sol
@@ -10,12 +10,7 @@ import {ERC1155, ERC1155TokenReceiver} from "@solbase/tokens/ERC1155.sol";
 
 /// @notice ERC1155 vault with router and liquidity pools.
 /// @author z0r0z.eth (SolDAO)
-contract Helios is
-    OwnedThreeStep(tx.origin),
-    SafeMulticallable,
-    ERC1155,
-    ERC1155TokenReceiver
-{
+contract Helios is OwnedThreeStep(tx.origin), SafeMulticallable, ERC1155, ERC1155TokenReceiver {
     constructor() payable {} // Clean deployment.
 
     /// -----------------------------------------------------------------------
@@ -29,34 +24,13 @@ contract Helios is
     /// Events
     /// -----------------------------------------------------------------------
 
-    event CreatePair(
-        address indexed to,
-        uint256 id,
-        address indexed token0,
-        address indexed token1
-    );
+    event CreatePair(address indexed to, uint256 id, address indexed token0, address indexed token1);
 
-    event AddLiquidity(
-        address indexed to,
-        uint256 id,
-        uint256 token0amount,
-        uint256 token1amount
-    );
+    event AddLiquidity(address indexed to, uint256 id, uint256 token0amount, uint256 token1amount);
 
-    event RemoveLiquidity(
-        address indexed from,
-        uint256 id,
-        uint256 amount0out,
-        uint256 amount1out
-    );
+    event RemoveLiquidity(address indexed from, uint256 id, uint256 amount0out, uint256 amount1out);
 
-    event Swap(
-        address indexed to,
-        uint256 id,
-        address indexed tokenIn,
-        uint256 amountIn,
-        uint256 amountOut
-    );
+    event Swap(address indexed to, uint256 id, address indexed tokenIn, uint256 amountIn, uint256 amountOut);
 
     event SetURIfetcher(ERC1155 indexed uriFetcher);
 
@@ -102,8 +76,7 @@ contract Helios is
     mapping(uint256 => Pair) public pairs;
 
     /// @dev Internal mapping to check Helios LP settings.
-    mapping(address => mapping(address => mapping(IHelios => mapping(uint256 => uint256))))
-        internal pairSettings;
+    mapping(address => mapping(address => mapping(IHelios => mapping(uint256 => uint256)))) internal pairSettings;
 
     struct Pair {
         address token0; // First pair token.
@@ -156,27 +129,14 @@ contract Helios is
 
         require(address(swapper).code.length != 0, "Helios: INVALID_SWAPPER");
 
-        uint112 token0amount; 
-        uint112 token1amount; 
+        uint112 token0amount;
+        uint112 token1amount;
         // Sort tokens and amounts.
-        (
-            tokenA,
-            token0amount,
-            tokenB,
-            token1amount
-        ) = tokenA < tokenB
-                ? (tokenA, uint112(tokenAamount), tokenB, uint112(tokenBamount))
-                : (
-                    tokenB,
-                    uint112(tokenBamount),
-                    tokenA,
-                    uint112(tokenAamount)
-                );
+        (tokenA, token0amount, tokenB, token1amount) = tokenA < tokenB
+            ? (tokenA, uint112(tokenAamount), tokenB, uint112(tokenBamount))
+            : (tokenB, uint112(tokenBamount), tokenA, uint112(tokenAamount));
 
-        require(
-            pairSettings[tokenA][tokenB][swapper][fee] == 0,
-            "Helios: PAIR_EXISTS"
-        );
+        require(pairSettings[tokenA][tokenB][swapper][fee] == 0, "Helios: PAIR_EXISTS");
 
         // If null included or `msg.value`, assume native token pairing.
         if (address(tokenA) == address(0) || msg.value != 0) {
@@ -244,23 +204,11 @@ contract Helios is
         if (pair.token0 == address(0)) {
             token0amount = msg.value;
 
-            pair.token1.safeTransferFrom(
-                msg.sender,
-                address(this),
-                token1amount
-            );
+            pair.token1.safeTransferFrom(msg.sender, address(this), token1amount);
         } else {
-            pair.token0.safeTransferFrom(
-                msg.sender,
-                address(this),
-                token0amount
-            );
+            pair.token0.safeTransferFrom(msg.sender, address(this), token0amount);
 
-            pair.token1.safeTransferFrom(
-                msg.sender,
-                address(this),
-                token1amount
-            );
+            pair.token1.safeTransferFrom(msg.sender, address(this), token1amount);
         }
 
         // Swapper dictates output LP.
@@ -340,10 +288,7 @@ contract Helios is
 
         Pair storage pair = pairs[id];
 
-        require(
-            tokenIn == pair.token0 || tokenIn == pair.token1,
-            "Helios: NOT_PAIR_TOKEN"
-        );
+        require(tokenIn == pair.token0 || tokenIn == pair.token1, "Helios: NOT_PAIR_TOKEN");
 
         // If `tokenIn` is address(0), assume native token.
         if (tokenIn == address(0)) {
@@ -367,10 +312,7 @@ contract Helios is
             // We combine the updates into one write
             uint256 combinedUpdate = (amountIn << 112) - amountOut;
             assembly {
-                sstore(
-                    add(pair.slot, 3),
-                    add(sload(add(pair.slot, 3)), combinedUpdate)
-                )
+                sstore(add(pair.slot, 3), add(sload(add(pair.slot, 3)), combinedUpdate))
             }
         } else {
             pair.token1.safeTransfer(to, amountOut);
@@ -380,10 +322,7 @@ contract Helios is
             // We combine the updates into one write
             uint256 combinedUpdate = (amountOut << 112) - amountIn;
             assembly {
-                sstore(
-                    add(pair.slot, 3),
-                    sub(sload(add(pair.slot, 3)), combinedUpdate)
-                )
+                sstore(add(pair.slot, 3), sub(sload(add(pair.slot, 3)), combinedUpdate))
             }
         }
 
@@ -408,10 +347,7 @@ contract Helios is
 
         Pair storage pair = pairs[id];
 
-        require(
-            tokenIn == pair.token0 || tokenIn == pair.token1,
-            "Helios: NOT_PAIR_TOKEN"
-        );
+        require(tokenIn == pair.token0 || tokenIn == pair.token1, "Helios: NOT_PAIR_TOKEN");
 
         // Swapper dictates output amount.
         amountOut = pair.swapper.swap(id, address(tokenIn), amountIn);
@@ -459,12 +395,7 @@ contract Helios is
         address tokenOut = tokenIn;
 
         for (uint256 i; i < len; ) {
-            (tokenOut, amountOut) = _updateReserves(
-                to,
-                ids[i],
-                tokenOut,
-                amountOut
-            );
+            (tokenOut, amountOut) = _updateReserves(to, ids[i], tokenOut, amountOut);
 
             // Unchecked because the only math done is incrementing
             // the array index counter which cannot possibly overflow.
@@ -518,10 +449,7 @@ contract Helios is
             address token0 = pair.token0;
             address token1 = pair.token1;
 
-            require(
-                currentToken == token0 || currentToken == token1,
-                "Helios: NOT_PAIR_TOKEN"
-            );
+            require(currentToken == token0 || currentToken == token1, "Helios: NOT_PAIR_TOKEN");
 
             currentToken = (currentToken == token1) ? token0 : token1;
         }
@@ -544,10 +472,9 @@ contract Helios is
         if (opportunity.length == 0) return 0;
         (uint256 bestArbAmount, uint256 bestProfit) = _optimizeArb(0);
         uint256 bestOpportunity = 0;
-        for (uint256 i = 1; i < opportunity.length;) {
+        for (uint256 i = 1; i < opportunity.length; ) {
             (uint256 arbAmount, uint256 profit) = _optimizeArb(i);
-            if (profit > bestProfit)
-            {
+            if (profit > bestProfit) {
                 bestProfit = profit;
                 bestArbAmount = arbAmount;
                 bestOpportunity = i;
@@ -610,11 +537,7 @@ contract Helios is
     /// @param cycleId Index of cycle in the opportunity array.
     /// @return amountArb The amount to arb to maximize profit
     /// @return profit The estimated profit
-    function _optimizeArb(uint256 cycleId)
-        internal
-        view
-        returns (uint256, uint256)
-    {
+    function _optimizeArb(uint256 cycleId) internal view returns (uint256, uint256) {
         uint256[] memory cycle = opportunity[cycleId];
         Pair storage pair = pairs[cycle[0]];
         address tokenOut = pair.token1;
@@ -639,10 +562,9 @@ contract Helios is
                 ++i;
             }
         }
-        if (K > M){
+        if (K > M) {
             uint256 amountArb = (K * M).sqrt() - M;
-            if (K - M > (amountArb << 1))
-                return (amountArb, K - M  - (amountArb << 1));
+            if (K - M > (amountArb << 1)) return (amountArb, K - M - (amountArb << 1));
         }
         return (0, 0);
     }
@@ -699,10 +621,7 @@ contract Helios is
     /// @param cycleId The index of the cycle in the opportunity array
     /// @param amountIn The amount of arbToken to arb
     /// @return amountOut The profit amount
-    function executeArb(uint256 cycleId, uint256 amountIn)
-        public
-        returns (uint256 amountOut)
-    {
+    function executeArb(uint256 cycleId, uint256 amountIn) public returns (uint256 amountOut) {
         // Function is external to allow low-level call() (or try/catch)
         // However we need to prevent calls from outside this contract
         // since all checks have been moved to addOpportunity
@@ -713,12 +632,7 @@ contract Helios is
         uint256 initialAmountIn = amountIn;
         uint256 len = cycle.length;
         for (uint256 i; i < len; ) {
-            (currentToken, amountOut) = _updateReserves(
-                beneficiary,
-                cycle[i],
-                currentToken,
-                amountOut
-            );
+            (currentToken, amountOut) = _updateReserves(beneficiary, cycle[i], currentToken, amountOut);
 
             unchecked {
                 ++i;
@@ -745,8 +659,6 @@ contract Helios is
 
         uint256 newReserveIn = reserveAmountIn * 10000 + amountInWithFee;
 
-        amountOut =
-            (amountInWithFee * reserveAmountOut + (newReserveIn >> 1)) /
-            newReserveIn;
+        amountOut = (amountInWithFee * reserveAmountOut + (newReserveIn >> 1)) / newReserveIn;
     }
 }

--- a/src/HeliosReference.sol
+++ b/src/HeliosReference.sol
@@ -4,10 +4,12 @@ pragma solidity ^0.8.4;
 import {IHelios} from "./interfaces/IHelios.sol";
 import {OwnedThreeStep} from "@solbase/auth/OwnedThreeStep.sol";
 import {SafeTransferLib} from "@solbase/utils/SafeTransferLib.sol";
+import {FixedPointMathLib} from "@solbase/utils/FixedPointMathLib.sol";
 import {SafeMulticallable} from "@solbase/utils/SafeMulticallable.sol";
 import {ERC1155, ERC1155TokenReceiver} from "@solbase/tokens/ERC1155.sol";
 
 /// @notice ERC1155 vault with router and liquidity pools.
+/// @dev Reference implementation (emphasizes clarity, deemphasizes gas cost)
 /// @author z0r0z.eth (SolDAO)
 contract HeliosReference is
     OwnedThreeStep(tx.origin),
@@ -22,6 +24,7 @@ contract HeliosReference is
     /// -----------------------------------------------------------------------
 
     using SafeTransferLib for address;
+    using FixedPointMathLib for uint256;
 
     /// -----------------------------------------------------------------------
     /// Events
@@ -57,6 +60,14 @@ contract HeliosReference is
     );
 
     event SetURIfetcher(ERC1155 indexed uriFetcher);
+
+    event AddOpportunity(uint256 id, uint256[] opportunity);
+
+    event ClearOpportunities();
+
+    event SetArbToken(address indexed token);
+
+    event SetArbBeneficiary(address indexed recipient);
 
     /// -----------------------------------------------------------------------
     /// Metadata/URI Logic
@@ -105,6 +116,19 @@ contract HeliosReference is
     }
 
     /// -----------------------------------------------------------------------
+    /// Arb Storage
+    /// -----------------------------------------------------------------------
+
+    /// @dev Token that will be used for profits
+    address arbToken;
+
+    /// @dev Account where arb profits will be deposited
+    address beneficiary;
+
+    /// @dev List of arbitrage opportunities
+    uint256[][] opportunity;
+
+    /// -----------------------------------------------------------------------
     /// LP Logic
     /// -----------------------------------------------------------------------
 
@@ -133,12 +157,14 @@ contract HeliosReference is
 
         require(address(swapper).code.length != 0, "Helios: INVALID_SWAPPER");
 
+        uint112 token0amount; 
+        uint112 token1amount; 
         // Sort tokens and amounts.
         (
-            address token0,
-            uint112 token0amount,
-            address token1,
-            uint112 token1amount
+            tokenA,
+            token0amount,
+            tokenB,
+            token1amount
         ) = tokenA < tokenB
                 ? (tokenA, uint112(tokenAamount), tokenB, uint112(tokenBamount))
                 : (
@@ -149,23 +175,23 @@ contract HeliosReference is
                 );
 
         require(
-            pairSettings[token0][token1][swapper][fee] == 0,
+            pairSettings[tokenA][tokenB][swapper][fee] == 0,
             "Helios: PAIR_EXISTS"
         );
 
         // If null included or `msg.value`, assume native token pairing.
-        if (address(token0) == address(0) || msg.value != 0) {
+        if (address(tokenA) == address(0) || msg.value != 0) {
             // Overwrite token0 with null if not so.
-            if (token0 != address(0)) token0 = address(0);
+            if (tokenA != address(0)) tokenA = address(0);
 
             // Overwrite token0amount with value.
             token0amount = uint112(msg.value);
 
-            token1.safeTransferFrom(msg.sender, address(this), token1amount);
+            tokenB.safeTransferFrom(msg.sender, address(this), token1amount);
         } else {
-            token0.safeTransferFrom(msg.sender, address(this), token0amount);
+            tokenA.safeTransferFrom(msg.sender, address(this), token0amount);
 
-            token1.safeTransferFrom(msg.sender, address(this), token1amount);
+            tokenB.safeTransferFrom(msg.sender, address(this), token1amount);
         }
 
         // Unchecked because the only math done is incrementing
@@ -174,11 +200,11 @@ contract HeliosReference is
             id = ++totalSupply;
         }
 
-        pairSettings[token0][token1][swapper][fee] = id;
+        pairSettings[tokenA][tokenB][swapper][fee] = id;
 
         pairs[id] = Pair({
-            token0: token0,
-            token1: token1,
+            token0: tokenA,
+            token1: tokenB,
             swapper: swapper,
             reserve0: token0amount,
             reserve1: token1amount,
@@ -192,7 +218,7 @@ contract HeliosReference is
 
         totalSupplyForId[id] = liq;
 
-        emit CreatePair(to, id, token0, token1);
+        emit CreatePair(to, id, tokenA, tokenB);
 
         emit AddLiquidity(to, id, token0amount, token1amount);
     }
@@ -349,6 +375,7 @@ contract HeliosReference is
         }
 
         emit Swap(to, id, tokenIn, amountIn, amountOut);
+        _arb();
     }
 
     /// @notice Update reserves of Helios LP.
@@ -438,5 +465,275 @@ contract HeliosReference is
         } else {
             tokenOut.safeTransfer(to, amountOut);
         }
+        _arb();
+    }
+
+    /// -----------------------------------------------------------------------
+    /// Arbitrage logic
+    /// -----------------------------------------------------------------------
+
+    /// @notice Set the arbitrage token.
+    /// @param token Profits will be taken / denominated in this token.
+    function setArbToken(address token) external onlyOwner {
+        require(opportunity.length == 0, "Helios: NONEMPTY_OPPORTUNITIES");
+        arbToken = token;
+        emit SetArbToken(token);
+    }
+
+    /// @notice Set the account which will collect all arbitrage profits.
+    /// @param recipient Profits will be transferred to this address.
+    function setArbBeneficiary(address recipient) external onlyOwner {
+        beneficiary = recipient;
+        emit SetArbBeneficiary(recipient);
+    }
+
+    /// @notice Add an arbitrage cycle into consideration.
+    /// @param cycle Array of Helios LP ids in 1155 tracking.
+    function addOpportunity(uint256[] calldata cycle) public onlyOwner {
+        uint256 opp = opportunity.length;
+        address currentToken = arbToken;
+        uint256 len = cycle.length;
+
+        require(len > 0, "Helios: NOT_CYCLE");
+
+        for (uint256 i = 0; i < len; ++i) {
+            uint256 id = cycle[i];
+
+            require(id <= totalSupply, "Helios: PAIR_DOESNT_EXIST");
+
+            Pair storage pair = pairs[id];
+            address token0 = pair.token0;
+            address token1 = pair.token1;
+
+            require(
+                currentToken == token0 || currentToken == token1,
+                "Helios: NOT_PAIR_TOKEN"
+            );
+
+            currentToken = (currentToken == token1) ? token0 : token1;
+        }
+        require(currentToken == arbToken, "Helios: NOT_CYCLE");
+
+        opportunity.push(cycle);
+
+        emit AddOpportunity(opp, cycle);
+    }
+
+    /// @notice Remove all arbitrage cycles from consideration.
+    function clearOpportunities() public onlyOwner {
+        delete opportunity;
+        emit ClearOpportunities();
+    }
+
+    /// @notice Calculate and execute arbitrage if necessary.
+    /// @return the amount of profit from the arbitrage.
+    function _arb() internal returns (uint256) {
+        if (opportunity.length == 0) return 0;
+        (uint256 bestArbAmount, uint256 bestProfit) = _optimizeArb(0);
+        uint256 bestOpportunity = 0;
+        for (uint256 i = 1; i < opportunity.length;) {
+            (uint256 arbAmount, uint256 profit) = _optimizeArb(i);
+            if (profit > bestProfit)
+            {
+                bestProfit = profit;
+                bestArbAmount = arbAmount;
+                bestOpportunity = i;
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        if (bestProfit == 0) return 0;
+        (bool success, bytes memory result) = address(this).call(
+            abi.encodeCall(this.executeArb, (bestOpportunity, bestArbAmount))
+        );
+        return success ? abi.decode(result, (uint256)) : 0;
+    }
+
+    /// @notice Updates K, M according to the arb recurrence (cf. whitepaper)
+    /// @param id The Helios LP id in 1155 tracking
+    /// @param tokenIn The asset to swap from
+    /// @param K The K value
+    /// @param M The M value
+    /// @return tokenOut The asset to swap to
+    /// @return Knew new value of K
+    /// @return Mnew new value of M
+    function _updateRecurrence(
+        uint256 id,
+        address tokenIn,
+        uint256 K,
+        uint256 M
+    )
+        internal
+        view
+        returns (
+            address tokenOut,
+            uint256 Knew,
+            uint256 Mnew
+        )
+    {
+        Pair storage pair = pairs[id];
+        address token0 = pair.token0;
+        address token1 = pair.token1;
+
+        uint256 reserveIn;
+        uint256 reserveOut;
+        if (tokenIn == token1) {
+            tokenOut = token0;
+            reserveIn = pair.reserve1;
+            reserveOut = pair.reserve0;
+        } else {
+            tokenOut = token1;
+            reserveIn = pair.reserve0;
+            reserveOut = pair.reserve1;
+        }
+        uint256 fee = pair.fee;
+        Mnew = M - pair.swapper.getAmountOut(K, reserveIn, M, fee);
+        Knew = pair.swapper.getAmountOut(K, reserveIn, reserveOut, fee);
+    }
+
+    /// @notice calculate the amount to arb for a given opportunity
+    /// @notice All checks done earlier in addOpportunity; no checks here.
+    /// @param cycleId Index of cycle in the opportunity array.
+    /// @return amountArb The amount to arb to maximize profit
+    /// @return profit The estimated profit
+    function _optimizeArb(uint256 cycleId)
+        internal
+        view
+        returns (uint256, uint256)
+    {
+        uint256[] memory cycle = opportunity[cycleId];
+        Pair storage pair = pairs[cycle[0]];
+        address tokenOut = pair.token1;
+        uint256 K;
+        uint256 M;
+        if (arbToken == tokenOut) {
+            //tokenIn = token1 reserveIn=reserve1
+            tokenOut = pair.token0;
+            K = pair.reserve0;
+            M = pair.reserve1;
+        } else {
+            //tokenIn = token0 reserveIn=reserve0
+            K = pair.reserve1;
+            M = pair.reserve0;
+        }
+        M = (10000 * M) / (10000 - pair.fee);
+
+        uint256 len = cycle.length;
+        for (uint256 i = 1; i < len; ) {
+            (tokenOut, K, M) = _updateRecurrence(cycle[i], tokenOut, K, M);
+            unchecked {
+                ++i;
+            }
+        }
+        if (K > M){
+            uint256 amountArb = (K * M).sqrt() - M;
+            if (K - M > (amountArb << 1))
+                return (amountArb, K - M  - (amountArb << 1));
+        }
+        return (0, 0);
+    }
+
+    /// @notice Update reserves of Helios LP along an arbitrage cycle.
+    /// @notice All checks done earlier in addOpportunity; no checks here.
+    /// @param to The recipient, only used for logging events
+    /// @param cycleId The index of the cycle in the opportunity array
+    /// @param amountIn The amount of arbToken to swap
+    /// @return amountOut The amount of arbToken to receive
+    function _updateReservesUnchecked(
+        address to,
+        uint256 cycleId,
+        uint256 amountIn
+    ) internal returns (uint256 amountOut) {
+        uint256[] memory ids = opportunity[cycleId];
+        address currentToken = arbToken;
+        uint256 len = ids.length;
+        for (uint256 i; i < len; ) {
+            uint256 id = ids[i];
+            Pair storage pair = pairs[id];
+
+            // Swapper dictates output amount.
+            amountOut = pair.swapper.swap(id, address(currentToken), amountIn);
+
+            emit Swap(to, id, currentToken, amountIn, amountOut);
+
+            if (currentToken == pair.token1) {
+                currentToken = pair.token0;
+
+                pair.reserve0 -= uint112(amountOut);
+
+                pair.reserve1 += uint112(amountIn);
+            } else {
+                currentToken = pair.token1;
+
+                pair.reserve0 += uint112(amountIn);
+
+                pair.reserve1 -= uint112(amountOut);
+            }
+
+            amountIn = amountOut;
+
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
+    /// @notice Execute an arb trade along the given arb cycle.
+    /// @dev All checks done earlier in addOpportunity; no checks here.
+    /// @dev This function should be low-level call'ed.
+    /// @dev It may revert but caller changes (swap) should persist.
+    /// @param cycleId The index of the cycle in the opportunity array
+    /// @param amountIn The amount of arbToken to arb
+    /// @return amountOut The profit amount
+    function executeArb(uint256 cycleId, uint256 amountIn)
+        public
+        returns (uint256 amountOut)
+    {
+        // Function is external to allow low-level call() (or try/catch)
+        // However we need to prevent calls from outside this contract
+        // since all checks have been moved to addOpportunity
+        require(msg.sender == address(this));
+        amountOut = amountIn;
+        uint256[] memory cycle = opportunity[cycleId];
+        address currentToken = arbToken;
+        uint256 initialAmountIn = amountIn;
+        uint256 len = cycle.length;
+        for (uint256 i; i < len; ) {
+            (currentToken, amountOut) = _updateReserves(
+                beneficiary,
+                cycle[i],
+                currentToken,
+                amountOut
+            );
+
+            unchecked {
+                ++i;
+            }
+        }
+        // Optimal arb was derived using real numbers.
+        // Still a small chance that rounding can lead to amountOut <= initialAmountIn
+        require(amountOut > initialAmountIn, "Helios: ARB_FAILED");
+        amountOut -= initialAmountIn;
+        if (address(arbToken) == address(0)) {
+            beneficiary.safeTransferETH(amountOut);
+        } else {
+            arbToken.safeTransfer(beneficiary, amountOut);
+        }
+    }
+
+    function _getAmountOut(
+        uint256 amountIn,
+        uint256 reserveAmountIn,
+        uint256 reserveAmountOut,
+        uint256 fee
+    ) internal pure returns (uint256 amountOut) {
+        uint256 amountInWithFee = amountIn * (10000 - fee);
+
+        uint256 newReserveIn = reserveAmountIn * 10000 + amountInWithFee;
+
+        amountOut =
+            (amountInWithFee * reserveAmountOut + (newReserveIn >> 1)) /
+            newReserveIn;
     }
 }

--- a/src/interfaces/IHelios.sol
+++ b/src/interfaces/IHelios.sol
@@ -22,9 +22,7 @@ interface IHelios {
         uint256 token1amount
     ) external returns (uint256 liq);
 
-    function removeLiquidity(uint256 id, uint256 liq)
-        external
-        returns (uint256 amount0out, uint256 amount1out);
+    function removeLiquidity(uint256 id, uint256 liq) external returns (uint256 amount0out, uint256 amount1out);
 
     function swap(
         uint256 id,

--- a/src/interfaces/IHelios.sol
+++ b/src/interfaces/IHelios.sol
@@ -31,4 +31,11 @@ interface IHelios {
         address tokenIn,
         uint256 amountIn
     ) external returns (uint256 amountOut);
+
+    function getAmountOut(
+        uint256 amountIn,
+        uint256 reserveAmountIn,
+        uint256 reserveAmountOut,
+        uint256 fee
+    ) external pure returns (uint256);
 }

--- a/src/swappers/XYKswapper.sol
+++ b/src/swappers/XYKswapper.sol
@@ -122,4 +122,18 @@ contract XYKswapper is ReentrancyGuard {
             (amountInWithFee * reserveAmountOut + (newReserveIn >> 1)) /
             newReserveIn;
     }
+
+    function getAmountOut(
+        uint256 amountIn,
+        uint256 reserveAmountIn,
+        uint256 reserveAmountOut,
+        uint256 fee
+    ) external pure returns (uint256 amountOut) {
+        amountOut = _getAmountOut(
+            amountIn,
+            reserveAmountIn,
+            reserveAmountOut,
+            fee
+        );
+    }
 }

--- a/src/swappers/XYKswapper.sol
+++ b/src/swappers/XYKswapper.sol
@@ -50,10 +50,7 @@ contract XYKswapper is ReentrancyGuard {
         if (totalSupply == 0) {
             liq = (token0amount * token1amount).sqrt() - MIN_LP;
         } else {
-            liq = min(
-                (token0amount * totalSupply) / reserve0,
-                (token1amount * totalSupply) / reserve1
-            );
+            liq = min((token0amount * totalSupply) / reserve0, (token1amount * totalSupply) / reserve1);
         }
 
         require(liq != 0, "XYKswapper: INSUFFICIENT_LIQUIDITY_MINTED");
@@ -76,10 +73,7 @@ contract XYKswapper is ReentrancyGuard {
 
         amount1out = (lp * reserve1) / totalSupply;
 
-        require(
-            amount0out != 0 && amount1out != 0,
-            "XYKswapper: INSUFFICIENT_LIQUIDITY_BURNED"
-        );
+        require(amount0out != 0 && amount1out != 0, "XYKswapper: INSUFFICIENT_LIQUIDITY_BURNED");
     }
 
     /// -----------------------------------------------------------------------
@@ -118,9 +112,7 @@ contract XYKswapper is ReentrancyGuard {
 
         uint256 newReserveIn = reserveAmountIn * 10000 + amountInWithFee;
 
-        amountOut =
-            (amountInWithFee * reserveAmountOut + (newReserveIn >> 1)) /
-            newReserveIn;
+        amountOut = (amountInWithFee * reserveAmountOut + (newReserveIn >> 1)) / newReserveIn;
     }
 
     function getAmountOut(
@@ -129,11 +121,6 @@ contract XYKswapper is ReentrancyGuard {
         uint256 reserveAmountOut,
         uint256 fee
     ) external pure returns (uint256 amountOut) {
-        amountOut = _getAmountOut(
-            amountIn,
-            reserveAmountIn,
-            reserveAmountOut,
-            fee
-        );
+        amountOut = _getAmountOut(amountIn, reserveAmountIn, reserveAmountOut, fee);
     }
 }

--- a/src/test/Helios.t.sol
+++ b/src/test/Helios.t.sol
@@ -51,129 +51,21 @@ contract HeliosTest is ERC1155TokenReceiver, Test {
         MockERC20(token1).approve(address(heliosRef), 1_000_000_0 ether);
         MockERC20(token2).approve(address(heliosRef), 1_000_000_0 ether);
 
-        (id01, ) = helios.createPair(
-            address(this),
-            token0,
-            token1,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            30,
-            ""
-        );
-        (id12, ) = helios.createPair(
-            address(this),
-            token1,
-            token2,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            30,
-            ""
-        );
-        (id02, ) = helios.createPair(
-            address(this),
-            token0,
-            token2,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            30,
-            ""
-        );
+        (id01, ) = helios.createPair(address(this), token0, token1, 1_000 ether, 1_000 ether, xykSwapper, 30, "");
+        (id12, ) = helios.createPair(address(this), token1, token2, 1_000 ether, 1_000 ether, xykSwapper, 30, "");
+        (id02, ) = helios.createPair(address(this), token0, token2, 1_000 ether, 1_000 ether, xykSwapper, 30, "");
 
-        (id010, ) = helios.createPair(
-            address(this),
-            token0,
-            token1,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            0,
-            ""
-        );
-        (id120, ) = helios.createPair(
-            address(this),
-            token1,
-            token2,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            0,
-            ""
-        );
-        (id020, ) = helios.createPair(
-            address(this),
-            token0,
-            token2,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            0,
-            ""
-        );
+        (id010, ) = helios.createPair(address(this), token0, token1, 1_000 ether, 1_000 ether, xykSwapper, 0, "");
+        (id120, ) = helios.createPair(address(this), token1, token2, 1_000 ether, 1_000 ether, xykSwapper, 0, "");
+        (id020, ) = helios.createPair(address(this), token0, token2, 1_000 ether, 1_000 ether, xykSwapper, 0, "");
 
-        heliosRef.createPair(
-            address(this),
-            token0,
-            token1,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            30,
-            ""
-        );
-        heliosRef.createPair(
-            address(this),
-            token1,
-            token2,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            30,
-            ""
-        );
-        heliosRef.createPair(
-            address(this),
-            token0,
-            token2,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            30,
-            ""
-        );
+        heliosRef.createPair(address(this), token0, token1, 1_000 ether, 1_000 ether, xykSwapper, 30, "");
+        heliosRef.createPair(address(this), token1, token2, 1_000 ether, 1_000 ether, xykSwapper, 30, "");
+        heliosRef.createPair(address(this), token0, token2, 1_000 ether, 1_000 ether, xykSwapper, 30, "");
 
-        heliosRef.createPair(
-            address(this),
-            token0,
-            token1,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            0,
-            ""
-        );
-        heliosRef.createPair(
-            address(this),
-            token1,
-            token2,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            0,
-            ""
-        );
-        heliosRef.createPair(
-            address(this),
-            token0,
-            token2,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            0,
-            ""
-        );
+        heliosRef.createPair(address(this), token0, token1, 1_000 ether, 1_000 ether, xykSwapper, 0, "");
+        heliosRef.createPair(address(this), token1, token2, 1_000 ether, 1_000 ether, xykSwapper, 0, "");
+        heliosRef.createPair(address(this), token0, token2, 1_000 ether, 1_000 ether, xykSwapper, 0, "");
     }
 
     function testHeliosCreation() public payable {
@@ -181,16 +73,7 @@ contract HeliosTest is ERC1155TokenReceiver, Test {
     }
 
     function testXYKpairCreation() public payable {
-        helios.createPair(
-            address(this),
-            token0,
-            token1,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            1,
-            ""
-        );
+        helios.createPair(address(this), token0, token1, 1_000 ether, 1_000 ether, xykSwapper, 1, "");
     }
 
     function testXYKpairSwap(uint256 amountIn) public payable {
@@ -260,39 +143,19 @@ contract HeliosTest is ERC1155TokenReceiver, Test {
     }
 
     function testXYKpairNoFeeInvariance(uint256 amountIn) public payable {
-        vm.assume(
-            amountIn > 100000 &&
-                amountIn < MockERC20(token0).balanceOf(address(this))
-        );
+        vm.assume(amountIn > 100000 && amountIn < MockERC20(token0).balanceOf(address(this)));
 
         uint256[] memory path = new uint256[](2);
         path[0] = id010;
         path[1] = id120;
 
         // First we do a round trip to snap amountIn to a nearby quantity that will be invariant to round trips.
-        uint256 amountOutFwd = helios.swap(
-            address(this),
-            path,
-            token0,
-            amountIn
-        );
-        uint256 amountOutBack = helios.swap(
-            address(this),
-            id120,
-            token2,
-            amountOutFwd
-        );
+        uint256 amountOutFwd = helios.swap(address(this), path, token0, amountIn);
+        uint256 amountOutBack = helios.swap(address(this), id120, token2, amountOutFwd);
 
-        amountOutBack = helios.swap(
-            address(this),
-            id010,
-            token1,
-            amountOutBack
-        );
+        amountOutBack = helios.swap(address(this), id010, token1, amountOutBack);
 
-        uint256 diff = amountIn > amountOutBack
-            ? amountIn - amountOutBack
-            : amountOutBack - amountIn;
+        uint256 diff = amountIn > amountOutBack ? amountIn - amountOutBack : amountOutBack - amountIn;
 
         if (diff > 512) {
             revert("more than 512 wei difference from round tripping");
@@ -307,17 +170,10 @@ contract HeliosTest is ERC1155TokenReceiver, Test {
 
         amountOutFwd = helios.swap(address(this), path, token0, amountIn);
         amountOutBack = helios.swap(address(this), id120, token2, amountOutFwd);
-        amountOutBack = helios.swap(
-            address(this),
-            id010,
-            token1,
-            amountOutBack
-        );
+        amountOutBack = helios.swap(address(this), id010, token1, amountOutBack);
 
         if (amountIn != amountOutBack) {
-            revert(
-                "round tripping with 0 fee does not give back original amount"
-            );
+            revert("round tripping with 0 fee does not give back original amount");
         }
         if (b0 != MockERC20(token0).balanceOf(address(this))) {
             revert("token 0 balance is messed up");
@@ -336,18 +192,8 @@ contract HeliosTest is ERC1155TokenReceiver, Test {
 
         uint256 amountOut1 = helios.swap(address(this), id01, token0, amountIn);
         uint256 amountOut2 = helios.swap(address(this), id01, token0, amountIn);
-        uint256 amountOutRef1 = heliosRef.swap(
-            address(this),
-            id01,
-            token0,
-            amountIn
-        );
-        uint256 amountOutRef2 = heliosRef.swap(
-            address(this),
-            id01,
-            token0,
-            amountIn
-        );
+        uint256 amountOutRef1 = heliosRef.swap(address(this), id01, token0, amountIn);
+        uint256 amountOutRef2 = heliosRef.swap(address(this), id01, token0, amountIn);
 
         require(amountOut1 == amountOutRef1, "amountOut1 does not match");
         require(amountOut2 == amountOutRef2, "amountOut2 does not match");

--- a/src/test/HeliosReference.t.sol
+++ b/src/test/HeliosReference.t.sol
@@ -34,10 +34,7 @@ contract HeliosReferenceTest is ERC1155TokenReceiver, Test {
         token0 = address(new MockERC20("Token0", "TKN0", 18));
         token1 = address(new MockERC20("Token1", "TKN1", 18));
         token2 = address(new MockERC20("Token2", "TKN2", 18));
-        require(
-            token1 > token0 && token0 > token2,
-            "tests assume addr(token1)>addr(token0)>addr(token2)"
-        );
+        require(token1 > token0 && token0 > token2, "tests assume addr(token1)>addr(token0)>addr(token2)");
 
         MockERC20(token0).mint(address(this), 1_000_000 ether);
         MockERC20(token1).mint(address(this), 1_000_000 ether);
@@ -47,67 +44,13 @@ contract HeliosReferenceTest is ERC1155TokenReceiver, Test {
         MockERC20(token1).approve(address(helios), 1_000_000_0 ether);
         MockERC20(token2).approve(address(helios), 1_000_000_0 ether);
 
-        (id01, ) = helios.createPair(
-            address(this),
-            token0,
-            token1,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            30,
-            ""
-        );
-        (id12, ) = helios.createPair(
-            address(this),
-            token1,
-            token2,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            30,
-            ""
-        );
-        (id02, ) = helios.createPair(
-            address(this),
-            token0,
-            token2,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            30,
-            ""
-        );
+        (id01, ) = helios.createPair(address(this), token0, token1, 1_000 ether, 1_000 ether, xykSwapper, 30, "");
+        (id12, ) = helios.createPair(address(this), token1, token2, 1_000 ether, 1_000 ether, xykSwapper, 30, "");
+        (id02, ) = helios.createPair(address(this), token0, token2, 1_000 ether, 1_000 ether, xykSwapper, 30, "");
 
-        (id010, ) = helios.createPair(
-            address(this),
-            token0,
-            token1,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            0,
-            ""
-        );
-        (id120, ) = helios.createPair(
-            address(this),
-            token1,
-            token2,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            0,
-            ""
-        );
-        (id020, ) = helios.createPair(
-            address(this),
-            token0,
-            token2,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            0,
-            ""
-        );
+        (id010, ) = helios.createPair(address(this), token0, token1, 1_000 ether, 1_000 ether, xykSwapper, 0, "");
+        (id120, ) = helios.createPair(address(this), token1, token2, 1_000 ether, 1_000 ether, xykSwapper, 0, "");
+        (id020, ) = helios.createPair(address(this), token0, token2, 1_000 ether, 1_000 ether, xykSwapper, 0, "");
     }
 
     function testHeliosCreation() public payable {
@@ -115,16 +58,7 @@ contract HeliosReferenceTest is ERC1155TokenReceiver, Test {
     }
 
     function testXYKpairCreation() public payable {
-        helios.createPair(
-            address(this),
-            token0,
-            token1,
-            1_000 ether,
-            1_000 ether,
-            xykSwapper,
-            1,
-            ""
-        );
+        helios.createPair(address(this), token0, token1, 1_000 ether, 1_000 ether, xykSwapper, 1, "");
     }
 
     function testXYKpairSwap(uint256 amountIn) public payable {
@@ -193,39 +127,19 @@ contract HeliosReferenceTest is ERC1155TokenReceiver, Test {
     }
 
     function testXYKpairNoFeeInvariance(uint256 amountIn) public payable {
-        vm.assume(
-            amountIn > 100000 &&
-                amountIn < MockERC20(token0).balanceOf(address(this))
-        );
+        vm.assume(amountIn > 100000 && amountIn < MockERC20(token0).balanceOf(address(this)));
 
         uint256[] memory path = new uint256[](2);
         path[0] = id010;
         path[1] = id120;
 
         // First we do a round trip to snap amountIn to a nearby quantity that will be invariant to round trips.
-        uint256 amountOutFwd = helios.swap(
-            address(this),
-            path,
-            token0,
-            amountIn
-        );
-        uint256 amountOutBack = helios.swap(
-            address(this),
-            id120,
-            token2,
-            amountOutFwd
-        );
+        uint256 amountOutFwd = helios.swap(address(this), path, token0, amountIn);
+        uint256 amountOutBack = helios.swap(address(this), id120, token2, amountOutFwd);
 
-        amountOutBack = helios.swap(
-            address(this),
-            id010,
-            token1,
-            amountOutBack
-        );
+        amountOutBack = helios.swap(address(this), id010, token1, amountOutBack);
 
-        uint256 diff = amountIn > amountOutBack
-            ? amountIn - amountOutBack
-            : amountOutBack - amountIn;
+        uint256 diff = amountIn > amountOutBack ? amountIn - amountOutBack : amountOutBack - amountIn;
 
         if (diff > 512) {
             revert("more than 512 wei difference from round tripping");
@@ -240,17 +154,10 @@ contract HeliosReferenceTest is ERC1155TokenReceiver, Test {
 
         amountOutFwd = helios.swap(address(this), path, token0, amountIn);
         amountOutBack = helios.swap(address(this), id120, token2, amountOutFwd);
-        amountOutBack = helios.swap(
-            address(this),
-            id010,
-            token1,
-            amountOutBack
-        );
+        amountOutBack = helios.swap(address(this), id010, token1, amountOutBack);
 
         if (amountIn != amountOutBack) {
-            revert(
-                "round tripping with 0 fee does not give back original amount"
-            );
+            revert("round tripping with 0 fee does not give back original amount");
         }
         if (b0 != MockERC20(token0).balanceOf(address(this))) {
             revert("token 0 balance is messed up");
@@ -283,5 +190,5 @@ contract HeliosReferenceTest is ERC1155TokenReceiver, Test {
         uint256 a0 = MockERC20(token0).balanceOf(deployer);
         require(a0 > b0 + 246 ether, "too little arbed");
         require(a0 < b0 + 247 ether, "too much arbed");
-     }
+    }
 }


### PR DESCRIPTION
This PR implements the ideas in [this paper](https://github.com/avaxmoon/self-arbing-dex/blob/main/main.pdf) [pdf] for Helios. 

The owner of the DEX can specify a token to collect profit on, a beneficiary (an account that collects arb profits), and a short list of arbitrage opportunities (c.f. paper). If this list of opportunities is non-empty, after every swap the contract will evaluate the opportunities and choose the one that results in maximum profit. If the profit is greater than 0 then arb trades are executed as if a flashloan was obtained (i.e. the beneficiary, on behalf of whom the trades are made, does not need to have the upfront capital to do the trades).

Gas-optimizations will come at subsequent PRs.

Algorithmic improvements so that not all opportunities are investingated are a subject of research. For example, if our opportunities only involve tokens A, B, C, D, but a trade involves swapping from E to F the contract need not spend any gas searching its opportunities.

 


